### PR TITLE
Update Travis' authorization.app.name check from 'Travis' to 'Travis CI'.

### DIFF
--- a/lib/travis-generator.js
+++ b/lib/travis-generator.js
@@ -202,7 +202,7 @@ TravisGenerator.prototype.checkIfTravisGitHubAppAuthorized = function () {
     this.get('github').authorization.getAll({}, defer.makeNodeResolver());
     return defer.promise.then(function (res) {
         if (_.any(res, function (authorization) {
-            return authorization.app.name === 'Travis' &&
+            return authorization.app.name === 'Travis CI' &&
                 authorization.app.url === 'https://travis-ci.org';
         })) {
             return q.resolve();


### PR DESCRIPTION
Looks like the app name for the Travis app on GitHub changed from 'Travis' to 'Travis CI' which causes the 'Ensure GitHub Travis App Authorized' step to falsely open the app authorization process in the browser.
